### PR TITLE
Agregué la excepción `RutInvalidoError` al archivo `rutificador/__init__.py`

### DIFF
--- a/rutificador/__init__.py
+++ b/rutificador/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-from .main import Rut, RutDigitoVerificador  # noqa: F401
+from .main import Rut, RutDigitoVerificador, RutInvalidoError  # noqa: F401


### PR DESCRIPTION
# Descripción del cambio:
El archivo `rutificador/__init__.py` no exporta la clase de Excepción `RutInvalidoError`, por lo que el control de errores en un programa que use el paquete no permite gestionar la excepción del módulo, sino requiere una gestión estándar:

```python
from rutificador import RutInvalidoError  # esto no funciona

try:
    rut = Rut(rut="12345678-9")
except RutInvalidoError:  # esto no funciona porque no se puede importar la clase de excepcion
    ...
except Exception:  # esto funciona, pero es indeseable
    ...
```

Para mejorar la gestión de errores, añadí a `__init__.py` la clase de excepción, de modo tal que se pueda importar la excepción apropiada y gestionar errores de buena manera en código.

# Motivo del cambio

De acuerdo con la documentación de Python, la [gestión de excepciones](https://docs.python.org/3/reference/compound_stmts.html#except-clause), los bloques `try:`-`except:` pueden tener excepciones nombradas, donde el stack verificará el nombre de la excepción para ejecutarse. De esta manera se consigue código claro, ordenado y autodocumentado. La gestión de excepciones _user-defined_ requiere que los módulos expongan sus excepciones, de forma de atrapar los errores y gestionarlos adecuadamente. 