### PR TITLE
Actualización de nombres y documentación a español

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Rutificador
 
-Una biblioteca Python para validar y formatear RUTs (Rol Único Tributario) chilenos.
+Biblioteca en Python para validar, calcular y formatear RUTs (Rol Único Tributario) chilenos de forma eficiente.
 
 ## Tabla de Contenidos
 
@@ -41,6 +41,7 @@ Una biblioteca Python para validar y formatear RUTs (Rol Único Tributario) chil
 - Manejo de excepciones personalizadas.
 - **Procesamiento de lotes de RUTs:** Permite procesar lotes de RUTs en lugar de hacerlo individualmente, lo que agiliza el trabajo con grandes cantidades de datos.
 - **Separación de resultados:** Los resultados de los lotes se entregan por separado, mostrando RUTs válidos e inválidos, y pueden exportarse en varios formatos, incluidos CSV, XML y JSON.
+- Compatibilidad con Python 3.9 o superior.
 
 ## Instalación
 

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -365,11 +365,10 @@ class TestProcesadorLotesRut:
         assert len(resultado.ruts_invalidos) == 1
         assert resultado.ruts_invalidos[0][0] == "98765432-1"
 
-    # Parametrization uses the expected output to validate the full
-    # formatted string (ignoring statistics lines which vary).  The
-    # dataset provides tuples of ``(formato, esperado)`` where
-    # ``esperado`` contains the initial part of the result up to the
-    # statistics section.
+    # La parametrización utiliza la salida esperada para validar toda la cadena
+    # formateada (ignorando las líneas de estadísticas que varían). El conjunto
+    # de datos provee tuplas ``(formato, esperado)`` donde ``esperado`` contiene
+    # el inicio del resultado hasta la sección de estadísticas.
     @pytest.mark.parametrize("formato, esperado", datos_test_formato)
     def test_formatear_lista_ruts_con_formato(self, formato, esperado):
         """Prueba formateo de lista con formato específico."""


### PR DESCRIPTION
## Resumen
- renombrar funciones y enumeraciones en `main.py`
- traducir docstrings y comentarios al español
- ajustar pruebas con comentarios en español
- mejorar README en español

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df005bb488328ac03a9071ff147a8