### PR TITLE
Add tests for invalid input handling in utils

### DIFF
--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -9,14 +9,28 @@ from rutificador.main import (
     configurar_registro,
     evaluar_rendimiento,
     Rut,
+    calcular_digito_verificador,
 )
 from rutificador import __version__
 from rutificador.formatter import FormateadorCSV
+from rutificador.exceptions import RutValidationError
 
 
 def test_normalizar_base_rut():
     assert normalizar_base_rut("12.345.678") == "12345678"
     assert normalizar_base_rut("000001") == "1"
+
+
+def test_calcular_digito_verificador_invalid_inputs():
+    with pytest.raises(RutValidationError):
+        calcular_digito_verificador("ABC123")
+    with pytest.raises(RutValidationError):
+        calcular_digito_verificador(12345678)  # type: ignore[arg-type]
+
+
+def test_normalizar_base_rut_invalid_type():
+    with pytest.raises(RutValidationError):
+        normalizar_base_rut(123)  # type: ignore[arg-type]
 
 
 def test_obtener_informacion_version():


### PR DESCRIPTION
## Summary
- test that `calcular_digito_verificador` rejects non-numeric and non-string inputs
- test that `normalizar_base_rut` raises on non-string values

## Testing
- `pytest -q`
- `pylint $(git ls-files '*.py')` (fails: missing docstring, duplicate code, cyclic import)
- `mypy rutificador/ --ignore-missing-imports` (fails: dict-item, no-redef, misc)
- `pre-commit run --files tests/test_additional.py` (fails: Username for 'https://gitlab.com')


------
https://chatgpt.com/codex/tasks/task_e_68b51ef6d30c8328a9e13d7925d6e3db