### PR TITLE
docs: agregar lineamientos en AGENTS y referencia

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Lineamientos para agentes
+
+Este repositorio utiliza las siguientes convenciones y prácticas:
+
+- **Idioma:** Usa español en los nombres de archivos, funciones, variables y comentarios.
+- **Principios de diseño:** Aplica SOLID, DRY y KISS; respeta PEP-8 y el Zen de Python.
+- **Calidad del código:** Ejecuta pruebas y linters antes de realizar un commit.
+- **Versionado:** Incrementa la versión en cada cambio.
+  - Se sigue el esquema de versionado semántico `MAJOR.MINOR.PATCH`.
+  - La versión se define en `pyproject.toml` (`tool.poetry.version`) y se expone en `rutificador/__init__.py` como `__version__`.
+- **Comprobaciones:** Usa `pre-commit` para linting y `pytest` para las pruebas.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ pytest
 
 ## Contribuciones
 
-Las contribuciones son bienvenidas. Solo debes hacer un fork del repositorio, crear una rama nueva, hacer los cambios que consideres pertinentes con su respectiva documentación, y finalmente hacer push y abrir un pull request para migrar los cambios al `master`.
+Las contribuciones son bienvenidas. Antes de comenzar, revisa las directrices en [AGENTS.md](AGENTS.md). Solo debes hacer un fork del repositorio, crear una rama nueva, hacer los cambios que consideres pertinentes con su respectiva documentación, y finalmente hacer push y abrir un pull request para migrar los cambios al `master`.
 
 ## Licencia
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rutificador"
-version = "0.4.4"
+version = "0.4.5"
 description = "Herramientas para validar, calcular y formatear el Rol Único Tributario (RUT) en Chile, con procesamiento por lotes y salida en múltiples formatos."
 authors = ["Carlos Ortega González <carlosortega77@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Resumen
- agregar archivo AGENTS.md con lineamientos de contribución
- referenciar AGENTS.md desde README.md
- incrementar versión a 0.4.5 en pyproject

## Pruebas
- `pre-commit run --files AGENTS.md README.md pyproject.toml` *(falla: repositorio de hook requiere autenticación)*
- `flake8`
- `black --check rutificador/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7095c948883288ec360712ca740f0