### PR TITLE
Centralizar versión en módulo dedicado

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,6 @@ Este repositorio utiliza las siguientes convenciones y prácticas:
 - **Calidad del código:** Ejecuta pruebas y linters antes de realizar un commit.
 - **Versionado:** Incrementa la versión en cada cambio.
   - Se sigue el esquema de versionado semántico `MAJOR.MINOR.PATCH`.
-  - La versión se define en `pyproject.toml` (`tool.poetry.version`) y se expone en `rutificador/__init__.py` como `__version__`.
+  - La versión se define en `rutificador/version.py` y se expone en `rutificador/__init__.py` como `__version__`.
+  - `pyproject.toml` obtiene la versión desde ese archivo mediante `poetry-dynamic-versioning`.
 - **Comprobaciones:** Usa `pre-commit` para linting y `pytest` para las pruebas.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ configurar_registro(level=logging.DEBUG)
 
 ### Información de versión
 
+La versión del paquete se define en `rutificador/version.py` y puede consultarse directamente:
+
+```python
+from rutificador import __version__
+
+print(__version__)
+```
+
+También puedes obtener metadatos adicionales:
+
 ```python
 from rutificador import obtener_informacion_version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rutificador"
-version = "0.4.5"
+version = "0.0.0"
 description = "Herramientas para validar, calcular y formatear el Rol Único Tributario (RUT) en Chile, con procesamiento por lotes y salida en múltiples formatos."
 authors = ["Carlos Ortega González <carlosortega77@gmail.com>"]
 license = "MIT"
@@ -46,6 +46,7 @@ addopts = ""
 
 [tool.poetry-dynamic-versioning]
 enable = true
+from-file = {source = "rutificador/version.py", pattern = "^__version__ = \"(.+)\""}
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/rutificador/__init__.py
+++ b/rutificador/__init__.py
@@ -1,22 +1,22 @@
 """
 Rutificador: Una biblioteca Python para validar y formatear RUTs chilenos.
 
-Este módulo proporciona herramientas para trabajar con RUTs chilenos (Rol Único Tributario),
-incluyendo validación, formateo y verificación de dígitos.
+Este módulo proporciona herramientas para trabajar con RUTs chilenos
+(Rol Único Tributario), incluyendo validación, formateo y verificación
+de dígitos.
 
 Clases:
-    Rut: Representa un RUT chileno, con métodos para validación y formateo.
-    RutDigitoVerificador: Calcula y representa el dígito verificador de un RUT chileno.
-    RutInvalidoError: Excepción personalizada para errores de RUT inválido.
+    Rut: Representa un RUT chileno, con métodos para validación y
+        formateo.
+    RutDigitoVerificador: Calcula y representa el dígito verificador
+        de un RUT chileno.
+    RutInvalidoError: Excepción personalizada para errores de RUT
+        inválido.
 """
 
-from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python < 3.11
-    import tomli as tomllib
 from typing import List, Type, Union
+
+from .version import __version__
 
 # Core classes
 from rutificador.main import Rut, RutBase, RutInvalidoError, RutValidator
@@ -36,29 +36,24 @@ from rutificador.main import (
     formatear_lista_ruts,
 )
 
-# Version info
-try:
-    __version__ = version("rutificador")
-except PackageNotFoundError:  # Fallback for local runs without installation
-    with open(Path(__file__).resolve().parent.parent / "pyproject.toml", "rb") as f:
-        __version__ = tomllib.load(f)["tool"]["poetry"]["version"]
 __author__ = "Carlos Ortega González"
 __license__ = "MIT"
 
 # Public API
 __all__: List[Union[str, Type]] = [
     # Core classes
-    'Rut',
-    'RutBase',
-    'RutInvalidoError',
-    'RutValidator',
+    "Rut",
+    "RutBase",
+    "RutInvalidoError",
+    "RutValidator",
     # Processing and formatting
-    'ProcesadorLotesRut',
-    'FabricaFormateadorRut',
-    'FormateadorCSV',
-    'FormateadorXML',
-    'FormateadorJSON',
+    "ProcesadorLotesRut",
+    "FabricaFormateadorRut",
+    "FormateadorCSV",
+    "FormateadorXML",
+    "FormateadorJSON",
     # Utility functions
-    'calcular_digito_verificador',
-    'formatear_lista_ruts',
+    "calcular_digito_verificador",
+    "formatear_lista_ruts",
+    "__version__",
 ]

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -1,0 +1,3 @@
+"""Módulo que define la versión de Rutificador."""
+
+__version__ = "0.4.6"


### PR DESCRIPTION
## Resumen
- mover la constante de versión a `rutificador/version.py`
- simplificar `rutificador/__init__` para importar `__version__`
- configurar `pyproject.toml` con `poetry-dynamic-versioning` desde el archivo de versión
- actualizar documentación y guías de contribución

## Pruebas
- `black rutificador/version.py rutificador/__init__.py`
- `flake8 rutificador/version.py rutificador/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c70b8acc888328898df3d74f22c70f