### PR TITLE
refactor: aplicar nombres y textos en español

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ print(xml_ruts)
 ### Personalizar la validación
 
 ```python
-from rutificador import Rut, RutValidator, RigorValidacion
+from rutificador import Rut, ValidadorRut, RigorValidacion
 
-validator = RutValidator(mode=RigorValidacion.FLEXIBLE)
-rut = Rut('12.345.678-5', validator=validator)
+validador = ValidadorRut(modo=RigorValidacion.FLEXIBLE)
+rut = Rut('12.345.678-5', validador=validador)
 print(rut)
 ```
 

--- a/rutificador/__init__.py
+++ b/rutificador/__init__.py
@@ -19,7 +19,7 @@ from typing import List, Type, Union
 from .version import __version__
 
 # Core classes
-from rutificador.main import Rut, RutBase, RutInvalidoError, RutValidator
+from rutificador.main import Rut, RutBase, RutInvalidoError, ValidadorRut, RutValidator
 
 # Processing and formatting
 from rutificador.main import ProcesadorLotesRut
@@ -45,6 +45,7 @@ __all__: List[Union[str, Type]] = [
     "Rut",
     "RutBase",
     "RutInvalidoError",
+    "ValidadorRut",
     "RutValidator",
     # Processing and formatting
     "ProcesadorLotesRut",

--- a/rutificador/config.py
+++ b/rutificador/config.py
@@ -1,42 +1,45 @@
-"""Configuration definitions for Rutificador."""
+"""Definiciones de configuración para Rutificador."""
 from dataclasses import dataclass
 from enum import Enum
 from typing import Tuple
 
 
 @dataclass(frozen=True)
-class RutConfig:
-    """Configuration class for RUT validation parameters."""
+class ConfiguracionRut:
+    """Clase de configuración para los parámetros de validación del RUT."""
 
-    verification_factors: Tuple[int, ...] = (2, 3, 4, 5, 6, 7)
+    factores_verificacion: Tuple[int, ...] = (2, 3, 4, 5, 6, 7)
     modulo: int = 11
-    max_digits: int = 8
-    min_digits: int = 1
+    max_digitos: int = 8
+    min_digitos: int = 1
 
     def __post_init__(self) -> None:
-        """Validate configuration parameters."""
+        """Valida los parámetros de configuración."""
         if self.modulo <= 0:
-            raise ValueError("Modulo must be positive")
-        if self.max_digits <= 0 or self.min_digits <= 0:
-            raise ValueError("Digit limits must be positive")
-        if self.min_digits > self.max_digits:
-            raise ValueError("Min digits cannot exceed max digits")
+            raise ValueError("El módulo debe ser positivo")
+        if self.max_digitos <= 0 or self.min_digitos <= 0:
+            raise ValueError("Los límites de dígitos deben ser positivos")
+        if self.min_digitos > self.max_digitos:
+            raise ValueError("El mínimo de dígitos no puede exceder al máximo")
 
 
-# Default configuration instance
-CONFIGURACION_POR_DEFECTO = RutConfig()
+# Instancia de configuración predeterminada
+CONFIGURACION_POR_DEFECTO = ConfiguracionRut()
 
 
 class RigorValidacion(Enum):
-    """Enumeration of validation strictness levels."""
+    """Enumeración de niveles de rigurosidad de validación."""
 
-    ESTRICTO = "strict"
-    FLEXIBLE = "lenient"
-    LEGADO = "legacy"
+    ESTRICTO = "estricto"
+    FLEXIBLE = "flexible"
+    LEGADO = "legado"
 
 
 __all__ = [
-    "RutConfig",
+    "ConfiguracionRut",
     "CONFIGURACION_POR_DEFECTO",
     "RigorValidacion",
 ]
+
+# Alias para compatibilidad retroactiva
+RutConfig = ConfiguracionRut

--- a/rutificador/exceptions.py
+++ b/rutificador/exceptions.py
@@ -1,76 +1,91 @@
-"""Custom exception hierarchy for Rutificador."""
+"""Jerarquía de excepciones personalizadas para Rutificador."""
 import logging
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 
-class RutError(Exception):
-    """Base exception for all RUT-related errors."""
+class ErrorRut(Exception):
+    """Excepción base para todos los errores relacionados con RUT."""
 
-    def __init__(self, message: str, error_code: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(
+        self, message: str, error_code: Optional[str] = None, **kwargs: Any
+    ) -> None:
         super().__init__(message)
         self.message = message
         self.error_code = error_code
-        self.context = kwargs
-        logger.error("RUT Error [%s]: %s", error_code, message, extra=kwargs)
+        self.contexto = kwargs
+        logger.error("Error de RUT [%s]: %s", error_code, message, extra=kwargs)
 
 
-class RutValidationError(RutError):
-    """Base class for validation-related errors."""
+class ErrorValidacionRut(ErrorRut):
+    """Excepción base para errores relacionados con la validación."""
 
 
-class RutFormatError(RutValidationError):
-    """Raised when RUT format is invalid."""
+class ErrorFormatoRut(ErrorValidacionRut):
+    """Se lanza cuando el formato del RUT es inválido."""
 
-    def __init__(self, rut_value: str, expected_format: str) -> None:
+    def __init__(self, valor_rut: str, formato_esperado: str) -> None:
         super().__init__(
-            f"Invalid RUT format: '{rut_value}'. Expected format: {expected_format}",
+            f"Formato de RUT inválido: '{valor_rut}'. Formato esperado: {formato_esperado}",
             error_code="FORMAT_ERROR",
-            rut_value=rut_value,
-            expected_format=expected_format,
+            rut_value=valor_rut,
+            expected_format=formato_esperado,
         )
 
 
-class RutDigitError(RutValidationError):
-    """Raised when verification digit is incorrect."""
+class ErrorDigitoRut(ErrorValidacionRut):
+    """Se lanza cuando el dígito verificador es incorrecto."""
 
-    def __init__(self, provided_digit: str, calculated_digit: str) -> None:
+    def __init__(self, digito_entregado: str, digito_calculado: str) -> None:
         super().__init__(
-            f"Verification digit mismatch: provided '{provided_digit}', calculated '{calculated_digit}'",
+            f"Dígito verificador no coincide: se entregó '{digito_entregado}', se calculó '{digito_calculado}'",
             error_code="DIGIT_ERROR",
-            provided_digit=provided_digit,
-            calculated_digit=calculated_digit,
+            provided_digit=digito_entregado,
+            calculated_digit=digito_calculado,
         )
 
 
-class RutLengthError(RutValidationError):
-    """Raised when RUT length is invalid."""
+class ErrorLongitudRut(ErrorValidacionRut):
+    """Se lanza cuando la longitud del RUT es inválida."""
 
-    def __init__(self, rut_value: str, length: int, max_length: int) -> None:
+    def __init__(self, valor_rut: str, longitud: int, longitud_maxima: int) -> None:
         super().__init__(
-            f"RUT '{rut_value}' exceeds maximum length: {length} > {max_length}",
+            f"El RUT '{valor_rut}' excede la longitud máxima: {longitud} > {longitud_maxima}",
             error_code="LENGTH_ERROR",
-            rut_value=rut_value,
-            length=length,
-            max_length=max_length,
+            rut_value=valor_rut,
+            length=longitud,
+            max_length=longitud_maxima,
         )
 
 
-class RutProcessingError(RutError):
-    """Raised during batch processing operations."""
+class ErrorProcesamientoRut(ErrorRut):
+    """Se lanza durante operaciones de procesamiento por lotes."""
 
 
-# Backward compatibility alias
-RutInvalidoError = RutValidationError
+# Alias para compatibilidad retroactiva
+RutInvalidoError = ErrorValidacionRut
+RutError = ErrorRut
+RutValidationError = ErrorValidacionRut
+RutFormatError = ErrorFormatoRut
+RutDigitError = ErrorDigitoRut
+RutLengthError = ErrorLongitudRut
+RutProcessingError = ErrorProcesamientoRut
 
 
 __all__ = [
+    "ErrorRut",
+    "ErrorValidacionRut",
+    "ErrorFormatoRut",
+    "ErrorDigitoRut",
+    "ErrorLongitudRut",
+    "ErrorProcesamientoRut",
+    "RutInvalidoError",
+    # Alias legados
     "RutError",
     "RutValidationError",
     "RutFormatError",
     "RutDigitError",
     "RutLengthError",
     "RutProcessingError",
-    "RutInvalidoError",
 ]

--- a/rutificador/formatter.py
+++ b/rutificador/formatter.py
@@ -1,4 +1,4 @@
-"""Utilities to format lists of Chilean RUT numbers."""
+"""Utilidades para formatear listas de números RUT chilenos."""
 
 import csv
 import html
@@ -22,10 +22,12 @@ class FormateadorRut(ABC):
     def validar_entrada(self, ruts: Sequence[str]) -> None:
         """Valida la entrada antes de formatear."""
         if not isinstance(ruts, (list, tuple)):
-            raise TypeError(f"Expected sequence, got {type(ruts).__name__}")
+            raise TypeError(
+                f"Se esperaba una secuencia, se recibió {type(ruts).__name__}"
+            )
 
         if not ruts:
-            logger.warning("Empty RUT sequence provided for formatting")
+            logger.warning("Se proporcionó una secuencia vacía de RUTs para formateo")
 
 
 class FormateadorCSV(FormateadorRut):
@@ -117,7 +119,7 @@ class FabricaFormateadorRut:
     def registrar_formateador(
         cls, nombre: str, clase_formateador: Type[FormateadorRut]
     ) -> None:
-        """Register a custom formatter class."""
+        """Registra una clase formateadora personalizada."""
         if not issubclass(clase_formateador, FormateadorRut):
             raise TypeError("El formateador debe heredar de FormateadorRut")
         cls._formatters[nombre.lower()] = clase_formateador
@@ -127,7 +129,7 @@ class FabricaFormateadorRut:
     def obtener_formateador(
         cls, formato: str, **kwargs: Any
     ) -> Optional[FormateadorRut]:
-        """Retrieve a formatter instance by name."""
+        """Obtiene una instancia de formateador por nombre."""
         if not isinstance(formato, str):
             return None
 
@@ -138,5 +140,5 @@ class FabricaFormateadorRut:
 
     @classmethod
     def obtener_formatos_disponibles(cls) -> List[str]:
-        """Return the list of supported formatter names."""
+        """Devuelve la lista de nombres de formateadores soportados."""
         return list(cls._formatters.keys())

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -1,3 +1,3 @@
 """Módulo que define la versión de Rutificador."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -13,7 +13,7 @@ from rutificador.main import (
 )
 from rutificador import __version__
 from rutificador.formatter import FormateadorCSV
-from rutificador.exceptions import RutValidationError
+from rutificador.exceptions import ErrorValidacionRut
 
 
 def test_normalizar_base_rut():
@@ -22,14 +22,14 @@ def test_normalizar_base_rut():
 
 
 def test_calcular_digito_verificador_invalid_inputs():
-    with pytest.raises(RutValidationError):
+    with pytest.raises(ErrorValidacionRut):
         calcular_digito_verificador("ABC123")
-    with pytest.raises(RutValidationError):
+    with pytest.raises(ErrorValidacionRut):
         calcular_digito_verificador(12345678)  # type: ignore[arg-type]
 
 
 def test_normalizar_base_rut_invalid_type():
-    with pytest.raises(RutValidationError):
+    with pytest.raises(ErrorValidacionRut):
         normalizar_base_rut(123)  # type: ignore[arg-type]
 
 

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -6,7 +6,7 @@ from rutificador.main import (
     Rut,
     RutBase,
     RutInvalidoError,
-    RutValidator,
+    ValidadorRut,
     ProcesadorLotesRut,
     FabricaFormateadorRut,
     FormateadorCSV,
@@ -117,60 +117,60 @@ class TestCalcularDigitoVerificador:
 # TESTS PARA RUTVALIDATOR
 # ============================================================================
 
-class TestRutValidator:
-    """Suite de pruebas para la clase RutValidator."""
+class TestValidadorRut:
+    """Suite de pruebas para la clase ValidadorRut."""
 
     def test_validar_formato_valido(self):
         """Prueba validación de formato válido."""
-        validator = RutValidator()
-        match = validator.validar_formato("12345678-5")
+        validador = ValidadorRut()
+        match = validador.validar_formato("12345678-5")
         assert match.group(1) == "12345678"
         assert match.group(3) == "5"
 
     def test_validar_formato_sin_digito(self):
         """Prueba validación de formato sin dígito verificador."""
-        validator = RutValidator()
-        match = validator.validar_formato("12345678")
+        validador = ValidadorRut()
+        match = validador.validar_formato("12345678")
         assert match.group(1) == "12345678"
         assert match.group(3) is None
 
     def test_validar_formato_none(self):
         """Prueba que None lance excepción."""
-        validator = RutValidator()
+        validador = ValidadorRut()
         with pytest.raises(RutInvalidoError):
-            validator.validar_formato(None)
+            validador.validar_formato(None)
 
     @pytest.mark.parametrize("base, rut_original, esperado", cadenas_base_validas)
     def test_validar_base_valida(self, base, rut_original, esperado):
         """Prueba validación de bases válidas."""
-        validator = RutValidator()
-        resultado = validator.validar_base(base, rut_original)
+        validador = ValidadorRut()
+        resultado = validador.validar_base(base, rut_original)
         assert resultado == esperado
 
     @pytest.mark.parametrize("base, rut_original", cadenas_base_invalidas)
     def test_validar_base_invalida(self, base, rut_original):
         """Prueba que bases inválidas lancen excepción."""
-        validator = RutValidator()
+        validador = ValidadorRut()
         with pytest.raises(RutInvalidoError):
-            validator.validar_base(base, rut_original)
+            validador.validar_base(base, rut_original)
 
     def test_validar_digito_verificador_correcto(self):
         """Prueba validación de dígito verificador correcto."""
         # No debería lanzar excepción
-        validator = RutValidator()
-        validator.validar_digito_verificador("5", "5")
+        validador = ValidadorRut()
+        validador.validar_digito_verificador("5", "5")
 
     def test_validar_digito_verificador_incorrecto(self):
         """Prueba validación de dígito verificador incorrecto."""
-        validator = RutValidator()
+        validador = ValidadorRut()
         with pytest.raises(RutInvalidoError):
-            validator.validar_digito_verificador("1", "5")
+            validador.validar_digito_verificador("1", "5")
 
     def test_validar_digito_verificador_none(self):
         """Prueba validación cuando no se proporciona dígito."""
         # No debería lanzar excepción cuando digito_input es None
-        validator = RutValidator()
-        validator.validar_digito_verificador(None, "5")
+        validador = ValidadorRut()
+        validador.validar_digito_verificador(None, "5")
 
 
 # ============================================================================
@@ -293,7 +293,7 @@ class TestRut:
     def test_cadenas_rut_validas(self, cadena_rut):
         """Prueba que las cadenas RUT válidas se manejen correctamente."""
         rut = Rut(cadena_rut)
-        assert rut.rut_string == cadena_rut.strip()
+        assert rut.cadena_rut == cadena_rut.strip()
 
     @pytest.mark.parametrize("cadena_rut", cadenas_rut_invalidas)
     def test_cadenas_rut_invalidas(self, cadena_rut):
@@ -399,7 +399,7 @@ class TestProcesadorLotesRut:
         with pytest.raises(ValueError) as exc_info:
             processor = ProcesadorLotesRut()
             processor.formatear_lista_ruts(ruts, formato="pdf")
-        assert "Format 'pdf' not supported" in str(exc_info.value)
+        assert "Formato 'pdf' no soportado" in str(exc_info.value)
 
 
 # ============================================================================


### PR DESCRIPTION
## Resumen
- renombrar configuraciones y enum de validación a nomenclatura española
- sustituir jerarquía de excepciones y validador por equivalentes en español
- traducir documentación y actualizar README y pruebas

## Testing
- `pre-commit run --files README.md rutificador/__init__.py rutificador/config.py rutificador/exceptions.py rutificador/formatter.py rutificador/main.py rutificador/utils.py rutificador/version.py tests/test_additional.py tests/test_rutificador.py` *(falló: Username for 'https://gitlab.com')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70e947ae88328a06f7885f8984989