### PR TITLE
feat: paralelizar validación y formateo de RUTs

### DIFF
--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 def obtener_informacion_version() -> Dict[str, str]:


### PR DESCRIPTION
## Resumen
- Añade procesamiento paralelo opcional para validar y formatear lotes de RUTs preservando el orden.
- Incrementa la versión a 1.0.3.
- Agrega pruebas que comparan el modo paralelo con el secuencial.

## Pruebas
- `pytest`
- `pre-commit run --files rutificador/procesador.py rutificador/version.py tests/test_rutificador.py` *(falla: solicita credenciales de gitlab.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c71e8f61548328a36512672a512d86