### PR TITLE
Evita conflicto de artefactos en workflow de seguridad

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: security-reports
+        name: security-reports-${{ matrix.python-version }}
         path: |
           bandit-report.json
           safety-report.json

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def obtener_informacion_version() -> Dict[str, str]:


### PR DESCRIPTION
## Resumen
- evita conflicto al subir reportes de seguridad nombrando cada artefacto por versión de Python
- incrementa la versión del paquete a 1.0.4

## Pruebas
- `pre-commit run --files .github/workflows/security.yml rutificador/version.py` *(falla: solicita credenciales de gitlab.com)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c723cab36c8328a5883e78d64908da