### PR TITLE
feat: agregar funciones de procesamiento en streaming

### DIFF
--- a/rutificador/__init__.py
+++ b/rutificador/__init__.py
@@ -9,7 +9,9 @@ from .procesador import (
     ProcesadorLotesRut,
     ResultadoLote,
     formatear_lista_ruts,
+    formatear_stream_ruts,
     validar_lista_ruts,
+    validar_stream_ruts,
     evaluar_rendimiento,
 )
 from .formatter import (
@@ -56,7 +58,9 @@ __all__: List[Union[str, Type]] = [
     "calcular_digito_verificador",
     "normalizar_base_rut",
     "formatear_lista_ruts",
+    "formatear_stream_ruts",
     "validar_lista_ruts",
+    "validar_stream_ruts",
     "configurar_registro",
     "evaluar_rendimiento",
     "asegurar_cadena_no_vacia",

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -5,7 +5,9 @@ from rutificador import (
     obtener_informacion_version,
     monitor_de_rendimiento,
     formatear_lista_ruts as formatear_lista_ruts_global,
+    formatear_stream_ruts as formatear_stream_ruts_global,
     validar_lista_ruts as validar_lista_ruts_global,
+    validar_stream_ruts as validar_stream_ruts_global,
     configurar_registro,
     evaluar_rendimiento,
     Rut,
@@ -54,6 +56,24 @@ def test_global_validar_y_formatear():
     texto = formatear_lista_ruts_global(ruts, formato="csv")
     assert "rut" in texto
     assert "12345678-5" in texto
+
+
+def test_validar_stream_ruts_con_generador():
+    ruts = (r for r in ["12345678-5", "12345679-3", "12345678-9"])
+    resultados = list(validar_stream_ruts_global(ruts))
+    assert resultados[0] == (True, "12345678-5")
+    assert resultados[1] == (True, "12345679-3")
+    assert resultados[2][0] is False
+    assert resultados[2][1][0] == "12345678-9"
+
+
+def test_formatear_stream_ruts_con_generador():
+    ruts = (r for r in ["12345678-5", "12345679-3", "12345678-9"])
+    resultados = list(formatear_stream_ruts_global(ruts, separador_miles=True))
+    assert resultados[0] == (True, "12.345.678-5")
+    assert resultados[1] == (True, "12.345.679-3")
+    assert resultados[2][0] is False
+    assert resultados[2][1][0] == "12345678-9"
 
 
 def test_configurar_registro():


### PR DESCRIPTION
## Resumen
- añadir `validar_stream_ruts` y `formatear_stream_ruts` para procesar RUTs de manera incremental
- exportar las nuevas utilidades y actualizar la versión
- incorporar pruebas con generadores para validar el flujo en streaming

## Testing
- `pre-commit run --files rutificador/procesador.py rutificador/__init__.py rutificador/version.py tests/test_additional.py` *(falló: pidió credenciales de GitLab)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7225152348328821424c176e18ca7