### PR TITLE
feat: agregar interfaz de línea de comandos

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ class FormateadorLista(FormateadorRut):
 FabricaFormateadorRut.registrar_formateador('lista', FormateadorLista)
 ```
 
+### Uso desde la línea de comandos
+
+El paquete incluye un comando de consola llamado `rutificador` con dos subcomandos:
+
+- `rutificador validar [archivo]`: valida RUTs recibidos por `stdin` o desde un archivo.
+- `rutificador formatear [archivo]`: valida y formatea los RUTs; acepta las opciones `--separador-miles` y `--mayusculas`.
+
+Ejemplos:
+
+```bash
+$ echo "12345678-5" | rutificador validar
+12345678-5
+
+$ echo "12345678-5" | rutificador formatear --separador-miles
+12.345.678-5
+```
+
 ## Desarrollo
 
 ### Configuración del Entorno

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ tomli = { version = "^2.0", python = "<3.11" }
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"
 
+[tool.poetry.scripts]
+rutificador = "rutificador.cli:main"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # Use default import mode so that local package is discoverable without

--- a/rutificador/cli.py
+++ b/rutificador/cli.py
@@ -1,0 +1,87 @@
+import argparse
+import sys
+from typing import List, Optional
+
+from .procesador import validar_stream_ruts, formatear_stream_ruts
+
+
+def _leer_ruts(ruta_archivo: Optional[str]) -> List[str]:
+    """Lee RUTs desde un archivo o desde la entrada estándar."""
+    if ruta_archivo:
+        with open(ruta_archivo, encoding="utf-8") as archivo:
+            return [linea.strip() for linea in archivo if linea.strip()]
+    return [linea.strip() for linea in sys.stdin if linea.strip()]
+
+
+def _comando_validar(args: argparse.Namespace) -> int:
+    ruts = _leer_ruts(args.archivo)
+    codigo_salida = 0
+    for es_valido, resultado in validar_stream_ruts(ruts):
+        if es_valido:
+            print(resultado)
+        else:
+            codigo_salida = 1
+            rut, error = resultado
+            print(f"{rut} - {error}", file=sys.stderr)
+    return codigo_salida
+
+
+def _comando_formatear(args: argparse.Namespace) -> int:
+    ruts = _leer_ruts(args.archivo)
+    codigo_salida = 0
+    for es_valido, resultado in formatear_stream_ruts(
+        ruts,
+        separador_miles=args.separador_miles,
+        mayusculas=args.mayusculas,
+    ):
+        if es_valido:
+            print(resultado)
+        else:
+            codigo_salida = 1
+            rut, error = resultado
+            print(f"{rut} - {error}", file=sys.stderr)
+    return codigo_salida
+
+
+def _crear_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rutificador")
+    subparsers = parser.add_subparsers(dest="comando", required=True)
+
+    parser_validar = subparsers.add_parser(
+        "validar", help="Valida RUTs desde archivo o stdin"
+    )
+    parser_validar.add_argument(
+        "archivo", nargs="?", help="Ruta de archivo con RUTs (uno por línea)"
+    )
+    parser_validar.set_defaults(func=_comando_validar)
+
+    parser_formatear = subparsers.add_parser(
+        "formatear",
+        help="Valida y formatea RUTs",
+    )
+    parser_formatear.add_argument(
+        "archivo", nargs="?", help="Ruta de archivo con RUTs (uno por línea)"
+    )
+    parser_formatear.add_argument(
+        "--separador-miles",
+        action="store_true",
+        help="Agrega separador de miles",
+    )
+    parser_formatear.add_argument(
+        "--mayusculas",
+        action="store_true",
+        help="Convierte el resultado a mayúsculas",
+    )
+    parser_formatear.set_defaults(func=_comando_formatear)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _crear_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+"""Pruebas para la interfaz de línea de comandos."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ejecutar_cli(
+    *args: str, entrada: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    comando = [sys.executable, "-m", "rutificador.cli", *args]
+    return subprocess.run(
+        comando,
+        input=entrada,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_validar_desde_stdin():
+    entrada = "12345678-5\n12345678-9\n"
+    resultado = ejecutar_cli("validar", entrada=entrada)
+    assert "12345678-5" in resultado.stdout
+    assert "12345678-9" in resultado.stderr
+    assert resultado.returncode == 1
+
+
+def test_formatear_desde_archivo(tmp_path: Path):
+    archivo = tmp_path / "ruts.txt"
+    archivo.write_text("12345678-5\n", encoding="utf-8")
+    resultado = ejecutar_cli("formatear", str(archivo), "--separador-miles")
+    assert "12.345.678-5" in resultado.stdout
+    assert resultado.returncode == 0


### PR DESCRIPTION
## Resumen
- implementar CLI con comandos `validar` y `formatear`
- registrar `console_script` y documentar uso básico
- añadir pruebas de la CLI y aumentar versión

## Testing
- `python -m pre_commit run --files README.md pyproject.toml rutificador/version.py rutificador/cli.py tests/test_cli.py` *(falla: Authentication failed for 'https://gitlab.com/pycqa/flake8.git/')*
- `black rutificador/cli.py tests/test_cli.py rutificador/version.py`
- `flake8 rutificador/cli.py tests/test_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c72be1759c8328ac6f189e82d1a9c2