### PR TITLE
Corrige configuración de CI y cobertura

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,9 @@ repos:
     rev: 23.11.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 6.1.0
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.0
     hooks:
       - id: flake8
+        args: ["--max-line-length=88"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ tomli = { version = "^2.0", python = "<3.11" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"
+pytest-cov = "^5.0"
 
 [tool.poetry.scripts]
 rutificador = "rutificador.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 pytest
+pytest-cov
 black
 coveralls
 tomli
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 
 def obtener_informacion_version() -> Dict[str, str]:
@@ -11,7 +11,7 @@ def obtener_informacion_version() -> Dict[str, str]:
         "version": __version__,
         "author": "Carlos Ortega González",
         "license": "MIT",
-        "description": "Enhanced Chilean RUT validation and formatting library",
+        "description": ("Librería mejorada para validar y formatear RUT chileno"),
         "features": [
             "High-performance validation with caching",
             "Parallel batch processing",


### PR DESCRIPTION
## Resumen
- Corrige repositorio de flake8 en pre-commit y alinea la longitud de línea
- Añade pytest-cov a las dependencias de desarrollo
- Incrementa versión del paquete

## Pruebas
- `pre-commit run --files .pre-commit-config.yaml pyproject.toml requirements-dev.txt rutificador/version.py`
- `pytest --cov=rutificador`


------
https://chatgpt.com/codex/tasks/task_e_68c801e4d8cc8328a2038649a30e10d5