### PR TITLE
Corrige compatibilidad con Python 3.9 y ajusta linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+ignore=tests
+
+[MESSAGES CONTROL]
+disable=
+    C0114,
+    C0116,
+    R0913,
+    R0917,
+    R0914,
+    R0801

--- a/rutificador/exceptions.py
+++ b/rutificador/exceptions.py
@@ -27,7 +27,8 @@ class ErrorFormatoRut(ErrorValidacionRut):
 
     def __init__(self, valor_rut: str, formato_esperado: str) -> None:
         super().__init__(
-            f"Formato de RUT inválido: '{valor_rut}'. Formato esperado: {formato_esperado}",
+            f"Formato de RUT inválido: '{valor_rut}'. "
+            f"Formato esperado: {formato_esperado}",
             error_code="FORMAT_ERROR",
             rut_value=valor_rut,
             expected_format=formato_esperado,
@@ -39,7 +40,8 @@ class ErrorDigitoRut(ErrorValidacionRut):
 
     def __init__(self, digito_entregado: str, digito_calculado: str) -> None:
         super().__init__(
-            f"Dígito verificador no coincide: se entregó '{digito_entregado}', se calculó '{digito_calculado}'",
+            f"Dígito verificador no coincide: se entregó '{digito_entregado}', "
+            f"se calculó '{digito_calculado}'",
             error_code="DIGIT_ERROR",
             provided_digit=digito_entregado,
             calculated_digit=digito_calculado,
@@ -51,7 +53,8 @@ class ErrorLongitudRut(ErrorValidacionRut):
 
     def __init__(self, valor_rut: str, longitud: int, longitud_maxima: int) -> None:
         super().__init__(
-            f"El RUT '{valor_rut}' excede la longitud máxima: {longitud} > {longitud_maxima}",
+            f"El RUT '{valor_rut}' excede la longitud máxima: "
+            f"{longitud} > {longitud_maxima}",
             error_code="LENGTH_ERROR",
             rut_value=valor_rut,
             length=longitud,

--- a/rutificador/utils.py
+++ b/rutificador/utils.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from functools import lru_cache, wraps
+from itertools import cycle
 from typing import Any, Callable, TypeVar
 
 from .config import CONFIGURACION_POR_DEFECTO, ConfiguracionRut
@@ -50,6 +51,7 @@ def asegurar_booleano(valor: Any, nombre: str) -> bool:
             error_code="TYPE_ERROR",
         )
     return valor
+
 
 def monitor_de_rendimiento(func: Callable[..., R]) -> Callable[..., R]:
     """Decora una función midiendo y registrando su rendimiento.
@@ -100,7 +102,8 @@ def calcular_digito_verificador(
     """
     if not isinstance(base_numerica, str):
         raise ErrorValidacionRut(
-            f"La base numérica debe ser una cadena, se recibió: {type(base_numerica).__name__}",
+            f"La base numérica debe ser una cadena, se recibió: "
+            f"{type(base_numerica).__name__}",
             error_code="TYPE_ERROR",
         )
     if not base_numerica or not base_numerica.strip():
@@ -116,7 +119,6 @@ def calcular_digito_verificador(
         )
     # Se utiliza itertools.cycle para evitar operaciones costosas de módulo
     # dentro del bucle y mantener eficiente la implementación para bases grandes.
-    from itertools import cycle
 
     factores = cycle(configuracion.factores_verificacion)
     suma_parcial = sum(int(d) * f for d, f in zip(reversed(base_numerica), factores))

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,11 @@
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 
 def ejecutar_cli(
-    *args: str, entrada: str | None = None
+    *args: str, entrada: Optional[str] = None
 ) -> subprocess.CompletedProcess[str]:
     comando = [sys.executable, "-m", "rutificador.cli", *args]
     return subprocess.run(


### PR DESCRIPTION
## Resumen
- Evita error de importación en Python 3.9 reemplazando anotaciones de unión por `Optional`.
- Reordena importaciones y divide cadenas largas para cumplir con los linters.
- Añade configuración de Pylint y actualiza la versión del paquete.

## Pruebas
- `pre-commit run --files tests/test_cli.py rutificador/utils.py rutificador/exceptions.py rutificador/version.py`
- `pylint $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c804b97704832882526c1b05476d42