### PR TITLE
Configura entorno release en publicación y actualiza versión

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,10 +13,8 @@ jobs:
   pypi-publish:
     name: Subir lanzamiento a PyPI
     runs-on: ubuntu-latest
-    # Agregar entorno específico para mayor seguridad
-    # environment:
-    #   name: pypi
-    #   url: https://pypi.org/p/rutificador
+    environment:
+      name: release
     permissions:
       id-token: write  # IMPORTANTE: este permiso es obligatorio para publicación confiable
       contents: read

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 
 def obtener_informacion_version() -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- define entorno de lanzamiento `release` para job de publicación en PyPI
- incrementa a versión 1.0.9

## Testing
- `pre-commit run --files .github/workflows/publish-package.yml rutificador/version.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c815d3e7f0832892e824bf2fef2ab4