### PR TITLE
Permite publicación manual en flujo de PyPI

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
 
     # Only run on tags or releases to prevent accidental publishing
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 
 def obtener_informacion_version() -> Dict[str, str]:


### PR DESCRIPTION
## Resumen
- Habilita ejecución manual del flujo de publicación a PyPI
- Incrementa versión del paquete a 1.0.10

## Pruebas
- `pre-commit run --files .github/workflows/publish-package.yml rutificador/version.py`
- `pytest`
- `act -n -W .github/workflows/publish-package.yml workflow_dispatch -j pypi-publish` *(falló: "no DOCKER_HOST and an invalid container socket")*

------
https://chatgpt.com/codex/tasks/task_e_68c81902688083289a436b43f7f96ec2