### PR TITLE
Permitir publicación en push

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
 
     # Only run on tags or releases to prevent accidental publishing
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
 
     steps:
       - name: Checkout code

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 
 
 def obtener_informacion_version() -> Dict[str, str]:


### PR DESCRIPTION
## Resumen
- Ejecutar flujo de publicación también en eventos `push`
- Aumentar versión interna a 1.0.11

## Pruebas
- `pre-commit run --files rutificador/version.py .github/workflows/publish-package.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81b7d8290832895e7f0cc492aa3f8