### PR TITLE
Agregar detalle de error en resultados de validación

### DIFF
--- a/rutificador/__init__.py
+++ b/rutificador/__init__.py
@@ -6,6 +6,7 @@ from .version import __version__, obtener_informacion_version
 from .validador import Validador, ValidadorRut, RutValidator
 from .rut import Rut, RutBase, obtener_rut
 from .procesador import (
+    DetalleError,
     ProcesadorLotesRut,
     ResultadoLote,
     formatear_lista_ruts,
@@ -48,6 +49,7 @@ __all__: List[Union[str, Type]] = [
     "Validador",
     "ValidadorRut",
     "RutValidator",
+    "DetalleError",
     "ProcesadorLotesRut",
     "ResultadoLote",
     "FabricaFormateadorRut",

--- a/rutificador/cli.py
+++ b/rutificador/cli.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 from typing import Iterator, Optional, List
 
-from .procesador import validar_stream_ruts, formatear_stream_ruts
+from .procesador import DetalleError, validar_stream_ruts, formatear_stream_ruts
 
 
 def _leer_ruts(ruta_archivo: Optional[str]) -> Iterator[str]:
@@ -20,6 +20,11 @@ def _leer_ruts(ruta_archivo: Optional[str]) -> Iterator[str]:
     return (linea.strip() for linea in sys.stdin if linea.strip())
 
 
+def _formatear_error(detalle: DetalleError) -> str:
+    codigo = detalle.codigo or "SIN_CODIGO"
+    return f"{detalle.rut} [{codigo}] - {detalle.mensaje}"
+
+
 def _comando_validar(args: argparse.Namespace) -> int:
     codigo_salida = 0
     for es_valido, resultado in validar_stream_ruts(_leer_ruts(args.archivo)):
@@ -27,8 +32,11 @@ def _comando_validar(args: argparse.Namespace) -> int:
             print(resultado)
         else:
             codigo_salida = 1
-            rut, error = resultado
-            print(f"{rut} - {error}", file=sys.stderr)
+            if isinstance(resultado, DetalleError):
+                print(_formatear_error(resultado), file=sys.stderr)
+            else:
+                rut, error = resultado
+                print(f"{rut} - {error}", file=sys.stderr)
     return codigo_salida
 
 
@@ -43,8 +51,11 @@ def _comando_formatear(args: argparse.Namespace) -> int:
             print(resultado)
         else:
             codigo_salida = 1
-            rut, error = resultado
-            print(f"{rut} - {error}", file=sys.stderr)
+            if isinstance(resultado, DetalleError):
+                print(_formatear_error(resultado), file=sys.stderr)
+            else:
+                rut, error = resultado
+                print(f"{rut} - {error}", file=sys.stderr)
     return codigo_salida
 
 

--- a/rutificador/rut.py
+++ b/rutificador/rut.py
@@ -34,7 +34,9 @@ class RutBase:
 class Rut:
     """Representación de un RUT chileno completo."""
 
-    def __init__(self, rut: Union[str, int], validador: Optional[ValidadorRut] = None) -> None:
+    def __init__(
+        self, rut: Union[str, int], validador: Optional[ValidadorRut] = None
+    ) -> None:
         if not isinstance(rut, (str, int)):
             raise ErrorValidacionRut(
                 f"El RUT debe ser cadena o entero, se recibió: {type(rut).__name__}",
@@ -42,7 +44,9 @@ class Rut:
             )
         self.cadena_rut = str(rut).strip()
         if not self.cadena_rut:
-            raise ErrorValidacionRut("El RUT no puede estar vacío", error_code="EMPTY_RUT")
+            raise ErrorValidacionRut(
+                "El RUT no puede estar vacío", error_code="EMPTY_RUT"
+            )
         self.validador = validador or ValidadorRut()
         self._analizar_y_validar()
 
@@ -57,7 +61,9 @@ class Rut:
 
         self.base = RutBase(self.cadena_base, self.cadena_rut)
         self.digito_verificador = calcular_digito_verificador(self.base.base)
-        self.validador.validar_digito_verificador(digito_ingresado, self.digito_verificador)
+        self.validador.validar_digito_verificador(
+            digito_ingresado, self.digito_verificador
+        )
         logger.debug("RUT validado correctamente: %s", self)
 
     def __str__(self) -> str:  # pragma: no cover - trivial
@@ -90,7 +96,10 @@ class Rut:
     ) -> str:
         asegurar_booleano(separador_miles, "separador_miles")
         asegurar_booleano(mayusculas, "mayusculas")
-        if not isinstance(separador_personalizado, str) or len(separador_personalizado) != 1:
+        if (
+            not isinstance(separador_personalizado, str)
+            or len(separador_personalizado) != 1
+        ):
             raise ErrorValidacionRut(
                 "separador_personalizado debe ser un único carácter",
                 error_code="FORMAT_ERROR",
@@ -112,7 +121,10 @@ class Rut:
         if len(numero) <= 3:
             return numero
         invertido = numero[::-1]
-        grupos = [invertido[i : i + 3] for i in range(0, len(invertido), 3)]
+        grupos = [
+            invertido[slice(inicio, inicio + 3)]
+            for inicio in range(0, len(invertido), 3)
+        ]
         formateado = separador.join(grupos)
         return formateado[::-1]
 

--- a/rutificador/validador.py
+++ b/rutificador/validador.py
@@ -3,7 +3,12 @@ import re
 from typing import Optional, Protocol, runtime_checkable, Match
 
 from .config import CONFIGURACION_POR_DEFECTO, ConfiguracionRut, RigorValidacion
-from .exceptions import ErrorFormatoRut, ErrorDigitoRut, ErrorLongitudRut, ErrorValidacionRut
+from .exceptions import (
+    ErrorFormatoRut,
+    ErrorDigitoRut,
+    ErrorLongitudRut,
+    ErrorValidacionRut,
+)
 from .utils import normalizar_base_rut, asegurar_cadena_no_vacia
 
 logger = logging.getLogger(__name__)
@@ -46,7 +51,10 @@ class ValidadorRut:
         if not match:
             raise ErrorFormatoRut(
                 cadena_rut,
-                "XXXXXXXX-X o XX.XXX.XXX-X donde X son dígitos y el último puede ser 'k'",
+                (
+                    "XXXXXXXX-X o XX.XXX.XXX-X donde X son dígitos "
+                    "y el último puede ser 'k'"
+                ),
             )
         logger.debug("Formato de RUT validado correctamente: %s", cadena_rut)
         return match
@@ -55,10 +63,7 @@ class ValidadorRut:
         """Valida y normaliza el número base del RUT."""
         base = asegurar_cadena_no_vacia(base, "base")
 
-        if not (
-            BASE_WITH_DOTS_REGEX.match(base)
-            or BASE_DIGITS_ONLY_REGEX.match(base)
-        ):
+        if not (BASE_WITH_DOTS_REGEX.match(base) or BASE_DIGITS_ONLY_REGEX.match(base)):
             raise ErrorFormatoRut(
                 base, "cadena numérica con separadores de miles opcionales"
             )

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -12,6 +12,7 @@ from rutificador import (
     evaluar_rendimiento,
     Rut,
     calcular_digito_verificador,
+    DetalleError,
     __version__,
 )
 from rutificador.formatter import FormateadorCSV
@@ -51,7 +52,10 @@ def test_global_validar_y_formatear():
     ruts = ["12345678-5", "12345679-5", "invalid"]
     resultado_validacion = validar_lista_ruts_global(ruts)
     assert "12345678-5" in resultado_validacion["validos"]
-    assert any("invalid" in tup[0] for tup in resultado_validacion["invalidos"])
+    assert any(
+        isinstance(detalle, DetalleError) and "invalid" in detalle.rut
+        for detalle in resultado_validacion["invalidos"]
+    )
 
     texto = formatear_lista_ruts_global(ruts, formato="csv")
     assert "rut" in texto
@@ -64,7 +68,9 @@ def test_validar_stream_ruts_con_generador():
     assert resultados[0] == (True, "12345678-5")
     assert resultados[1] == (True, "12345679-3")
     assert resultados[2][0] is False
-    assert resultados[2][1][0] == "12345678-9"
+    assert isinstance(resultados[2][1], DetalleError)
+    assert resultados[2][1].rut == "12345678-9"
+    assert resultados[2][1].codigo == "DIGIT_ERROR"
 
 
 def test_formatear_stream_ruts_con_generador():
@@ -73,7 +79,9 @@ def test_formatear_stream_ruts_con_generador():
     assert resultados[0] == (True, "12.345.678-5")
     assert resultados[1] == (True, "12.345.679-3")
     assert resultados[2][0] is False
-    assert resultados[2][1][0] == "12345678-9"
+    assert isinstance(resultados[2][1], DetalleError)
+    assert resultados[2][1].rut == "12345678-9"
+    assert resultados[2][1].codigo == "DIGIT_ERROR"
 
 
 def test_configurar_registro():

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -372,7 +372,9 @@ class TestProcesadorLotesRut:
 
         assert len(resultado.ruts_validos) == 2
         assert len(resultado.ruts_invalidos) == 1
-        assert resultado.ruts_invalidos[0][0] == "98765432-1"
+        detalle = resultado.ruts_invalidos[0]
+        assert detalle.rut == "98765432-1"
+        assert detalle.codigo == "DIGIT_ERROR"
 
     # La parametrización utiliza la salida esperada para validar toda la cadena
     # formateada (ignorando las líneas de estadísticas que varían). El conjunto


### PR DESCRIPTION
## Resumen
- agregar la clase `DetalleError` para enriquecer los resultados de validación con el código de error
- actualizar el procesador, las utilidades de flujo y la CLI para mostrar el código de error asociado
- ampliar las pruebas para verificar la presencia del código y ajustar la versión del paquete

## Pruebas
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8428774c083289b5cf1ad63a4fd25