### PR TITLE
feat: agregar formatos de salida en la CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ FabricaFormateadorRut.registrar_formateador('lista', FormateadorLista)
 El paquete incluye un comando de consola llamado `rutificador` con dos subcomandos:
 
 - `rutificador validar [archivo]`: valida RUTs recibidos por `stdin` o desde un archivo.
-- `rutificador formatear [archivo]`: valida y formatea los RUTs; acepta las opciones `--separador-miles` y `--mayusculas`.
+- `rutificador formatear [archivo]`: valida y formatea los RUTs; acepta `--separador-miles`, `--mayusculas` y `--formato {csv,xml,json}` para generar una salida agregada.
 
 Ejemplos:
 
@@ -232,6 +232,14 @@ $ echo "12345678-5" | rutificador validar
 
 $ echo "12345678-5" | rutificador formatear --separador-miles
 12.345.678-5
+
+$ echo "12345678-5" | rutificador formatear --formato json
+RUTs válidos:
+[
+  {
+    "rut": "12345678-5"
+  }
+]
 ```
 
 ## Desarrollo

--- a/rutificador/cli.py
+++ b/rutificador/cli.py
@@ -2,7 +2,11 @@ import argparse
 import sys
 from typing import Iterator, Optional, List
 
-from .procesador import validar_stream_ruts, formatear_stream_ruts
+from .procesador import (
+    validar_stream_ruts,
+    formatear_stream_ruts,
+    ProcesadorLotesRut,
+)
 
 
 def _leer_ruts(ruta_archivo: Optional[str]) -> Iterator[str]:
@@ -33,6 +37,19 @@ def _comando_validar(args: argparse.Namespace) -> int:
 
 
 def _comando_formatear(args: argparse.Namespace) -> int:
+    if getattr(args, "formato", None):
+        ruts = list(_leer_ruts(args.archivo))
+        procesador = ProcesadorLotesRut()
+        salida = procesador.formatear_lista_ruts(
+            ruts,
+            separador_miles=args.separador_miles,
+            mayusculas=args.mayusculas,
+            formato=args.formato,
+        )
+        print(salida)
+        resultado_validacion = procesador.validar_lista_ruts(ruts)
+        return 0 if not resultado_validacion.ruts_invalidos else 1
+
     codigo_salida = 0
     for es_valido, resultado in formatear_stream_ruts(
         _leer_ruts(args.archivo),
@@ -76,6 +93,11 @@ def _crear_parser() -> argparse.ArgumentParser:
         "--mayusculas",
         action="store_true",
         help="Convierte el resultado a mayúsculas",
+    )
+    parser_formatear.add_argument(
+        "--formato",
+        choices=["csv", "xml", "json"],
+        help="Genera salida agregada en el formato indicado",
     )
     parser_formatear.set_defaults(func=_comando_formatear)
 

--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,28 @@ def test_formatear_desde_archivo(tmp_path: Path):
     assert resultado.returncode == 0
 
 
+def test_formatear_formato_csv():
+    entrada = "12345678-5\n12345678-9\n"
+    resultado = ejecutar_cli("formatear", "--formato", "csv", entrada=entrada)
+    assert "rut\n12345678-5" in resultado.stdout
+    assert "12345678-9" in resultado.stdout
+    assert resultado.returncode == 1
+
+
+def test_formatear_formato_json():
+    entrada = "12345678-5\n"
+    resultado = ejecutar_cli("formatear", "--formato", "json", entrada=entrada)
+    assert '"rut": "12345678-5"' in resultado.stdout
+    assert resultado.returncode == 0
+
+
+def test_formatear_formato_xml():
+    entrada = "12345678-5\n"
+    resultado = ejecutar_cli("formatear", "--formato", "xml", entrada=entrada)
+    assert "<rut>12345678-5</rut>" in resultado.stdout
+    assert resultado.returncode == 0
+
+
 def test_memoria_validar_archivo_grande(tmp_path: Path, monkeypatch):
     archivo = tmp_path / "ruts.txt"
     archivo.write_text("12345678-5\n" * 500_000, encoding="utf-8")


### PR DESCRIPTION
## Resumen
- permitir `--formato {csv,xml,json}` en `rutificador formatear`
- usar `ProcesadorLotesRut.formatear_lista_ruts` para salida agregada
- documentar opción y pruebas para los tres formatos

## Pruebas
- `pre-commit run --files README.md rutificador/cli.py rutificador/version.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c82208267c8328897728015c7cfd9e