### PR TITLE
Incluye código de error en reportes de RUT inválidos

### DIFF
--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.14"
+__version__ = "1.0.15"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -60,6 +60,7 @@ def test_global_validar_y_formatear():
     texto = formatear_lista_ruts_global(ruts, formato="csv")
     assert "rut" in texto
     assert "12345678-5" in texto
+    assert "[FORMAT_ERROR]" in texto
 
 
 def test_validar_stream_ruts_con_generador():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def test_validar_desde_stdin():
     resultado = ejecutar_cli("validar", entrada=entrada)
     assert "12345678-5" in resultado.stdout
     assert "12345678-9" in resultado.stderr
+    assert "[DIGIT_ERROR]" in resultado.stderr
     assert resultado.returncode == 1
 
 

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -403,6 +403,8 @@ class TestProcesadorLotesRut:
         processor = ProcesadorLotesRut()
         resultado = processor.formatear_lista_ruts(ruts, formato=formato)
         assert "RUTs válidos:" in resultado
+        if "98765432-1" in ruts:
+            assert "[DIGIT_ERROR]" in resultado
 
     def test_formatear_lista_ruts_formato_invalido(self):
         """Prueba que formato inválido lance excepción."""


### PR DESCRIPTION
## Resumen
- centraliza la construcción de `DetalleError` al validar listas de RUT para conservar el código de error
- ajusta las pruebas de CLI y de formateo para comprobar que los códigos aparecen en la salida
- incrementa la versión del paquete

## Pruebas
- pytest
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c86f2b980483289f425417626dc938