### PR TITLE
Corrige advertencias de pylint en las pruebas

### DIFF
--- a/rutificador/version.py
+++ b/rutificador/version.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-__version__ = "1.0.15"
+__version__ = "1.0.16"
 
 
 def obtener_informacion_version() -> Dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,11 @@
 
 import subprocess
 import sys
-import argparse
 import tracemalloc
 from pathlib import Path
 from typing import Optional
 
-import rutificador.cli as cli
+from rutificador import cli
 
 
 def ejecutar_cli(
@@ -51,11 +50,11 @@ def test_memoria_validar_archivo_grande(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(cli, "validar_stream_ruts", _consumir)
 
-    args = argparse.Namespace(archivo=str(archivo))
     tracemalloc.start()
-    cli._comando_validar(args)
+    codigo_salida = cli.main(["validar", str(archivo)])
     _, pico = tracemalloc.get_traced_memory()
     tracemalloc.stop()
+    assert codigo_salida == 0
     assert pico < 20 * 1024 * 1024
 
 
@@ -64,17 +63,16 @@ def test_memoria_formatear_archivo_grande(tmp_path: Path, monkeypatch):
     archivo.write_text("12345678-5\n" * 500_000, encoding="utf-8")
 
     def _consumir(ruts, separador_miles, mayusculas):
+        del separador_miles, mayusculas
         for _ in ruts:
             pass
         return []
 
     monkeypatch.setattr(cli, "formatear_stream_ruts", _consumir)
 
-    args = argparse.Namespace(
-        archivo=str(archivo), separador_miles=False, mayusculas=False
-    )
     tracemalloc.start()
-    cli._comando_formatear(args)
+    codigo_salida = cli.main(["formatear", str(archivo)])
     _, pico = tracemalloc.get_traced_memory()
     tracemalloc.stop()
+    assert codigo_salida == 0
     assert pico < 20 * 1024 * 1024

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -450,6 +450,7 @@ class TestProcesadorLotesRut:
         llamados = []
 
         class EjecutorPrueba:
+            """Ejecutor simulado para registrar el parámetro ``max_workers``."""
             def __init__(self, max_workers=None):
                 llamados.append(max_workers)
 
@@ -475,6 +476,7 @@ class TestProcesadorLotesRut:
         llamados = []
 
         class EjecutorPrueba:
+            """Ejecutor simulado que verifica el valor personalizado."""
             def __init__(self, max_workers=None):
                 llamados.append(max_workers)
 


### PR DESCRIPTION
## Summary
- ajusta las pruebas de la CLI para usar la API pública y suprimir advertencias de pylint
- documenta las clases auxiliares de pruebas que carecían de docstring
- incrementa la versión del paquete a 1.0.16

## Testing
- pytest
- pylint $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68c8723208448328ba6d8a937451c0af