### PR TITLE
Format code to satisfy black

### DIFF
--- a/rutificador/config.py
+++ b/rutificador/config.py
@@ -1,4 +1,5 @@
 """Definiciones de configuración para Rutificador."""
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Tuple

--- a/rutificador/exceptions.py
+++ b/rutificador/exceptions.py
@@ -1,4 +1,5 @@
 """Jerarquía de excepciones personalizadas para Rutificador."""
+
 import logging
 from typing import Any, Optional
 

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -451,6 +451,7 @@ class TestProcesadorLotesRut:
 
         class EjecutorPrueba:
             """Ejecutor simulado para registrar el parámetro ``max_workers``."""
+
             def __init__(self, max_workers=None):
                 llamados.append(max_workers)
 
@@ -477,6 +478,7 @@ class TestProcesadorLotesRut:
 
         class EjecutorPrueba:
             """Ejecutor simulado que verifica el valor personalizado."""
+
             def __init__(self, max_workers=None):
                 llamados.append(max_workers)
 


### PR DESCRIPTION
## Summary
- run `black` to satisfy formatting for config, exception, and test modules

## Testing
- `python -m compileall rutificador tests`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d43e86ad8c832895fc96675ad9d95d