### PR TITLE
Fix custom validator handling for extended RUT lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ Antes de enviar tus cambios, verifica la calidad del código con:
 pre-commit run --files <archivos>
 pytest
 
+### Notas de validación
+
+- La suite incluye pruebas que aseguran el soporte de configuraciones
+  personalizadas de `ConfiguracionRut`, incluyendo bases de hasta 9 dígitos,
+  tanto para entradas con como sin dígito verificador. Esto evita regresiones
+  en escenarios donde se amplía `max_digitos` para integraciones externas.
+
 ## Problemas o Requerimientos
 
 ¿Te gustaría reportar algún error, solicitar alguna modificación o característica adicional en esta librería? Solo debes abrir un `issue` y describir tu petición de la forma más precisa y clara posible.

--- a/rutificador/rut.py
+++ b/rutificador/rut.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, InitVar
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import Any, Dict, Iterator, Optional, Union
@@ -17,14 +17,15 @@ class RutBase:
 
     base: str
     rut_original: str
+    validador: InitVar[Optional[ValidadorRut]] = None
 
-    def __post_init__(self) -> None:
+    def __post_init__(self, validador: Optional[ValidadorRut]) -> None:
         if not isinstance(self.rut_original, str):
             raise ErrorValidacionRut(
                 "El RUT original debe ser una cadena", error_code="TYPE_ERROR"
             )
-        validador = ValidadorRut()
-        base_validada = validador.validar_base(self.base, self.rut_original)
+        validador_instancia = validador or ValidadorRut()
+        base_validada = validador_instancia.validar_base(self.base, self.rut_original)
         object.__setattr__(self, "base", base_validada)
 
     def __str__(self) -> str:  # pragma: no cover - trivial
@@ -59,7 +60,7 @@ class Rut:
             self.cadena_base = match_result.group(1)
             digito_ingresado = match_result.group(3)
 
-        self.base = RutBase(self.cadena_base, self.cadena_rut)
+        self.base = RutBase(self.cadena_base, self.cadena_rut, self.validador)
         self.digito_verificador = calcular_digito_verificador(self.base.base)
         self.validador.validar_digito_verificador(
             digito_ingresado, self.digito_verificador

--- a/rutificador/validador.py
+++ b/rutificador/validador.py
@@ -14,7 +14,7 @@ from .utils import normalizar_base_rut, asegurar_cadena_no_vacia
 logger = logging.getLogger(__name__)
 
 # Expresiones regulares compiladas una vez
-RUT_REGEX = re.compile(r"^(\d{1,8}(?:\.\d{3})*)(-([0-9kK]))?$")
+RUT_REGEX = re.compile(r"^((?:\d{1,3}(?:\.\d{3})*)|\d+)(-([0-9kK]))?$")
 BASE_WITH_DOTS_REGEX = re.compile(r"^\d{1,3}(?:\.\d{3})*$")
 BASE_DIGITS_ONLY_REGEX = re.compile(r"^\d+$")
 
@@ -55,6 +55,13 @@ class ValidadorRut:
                     "XXXXXXXX-X o XX.XXX.XXX-X donde X son dígitos "
                     "y el último puede ser 'k'"
                 ),
+            )
+
+        base_capturada = match.group(1)
+        base_normalizada = normalizar_base_rut(base_capturada)
+        if len(base_normalizada) > self.configuracion.max_digitos:
+            raise ErrorLongitudRut(
+                cadena_rut, len(base_normalizada), self.configuracion.max_digitos
             )
         logger.debug("Formato de RUT validado correctamente: %s", cadena_rut)
         return match

--- a/tests/test_rutificador.py
+++ b/tests/test_rutificador.py
@@ -2,7 +2,9 @@
 
 import json
 from typing import List
+
 import pytest
+
 from rutificador import (
     Rut,
     RutBase,
@@ -16,6 +18,7 @@ from rutificador import (
     calcular_digito_verificador,
     formatear_lista_ruts,
 )
+from rutificador.config import ConfiguracionRut
 
 # ============================================================================
 # DATOS DE PRUEBA
@@ -345,6 +348,30 @@ class TestRut:
     def test_str_representation(self, rut_valido):
         """Prueba la representación string del RUT."""
         assert str(rut_valido) == "12345678-5"
+
+    def test_rut_respeta_configuracion_personalizada(self):
+        """Permite crear RUTs con configuraciones extendidas de dígitos."""
+
+        configuracion = ConfiguracionRut(max_digitos=9)
+        validador = ValidadorRut(configuracion=configuracion)
+        base_extendida = "123456789"
+        dv = calcular_digito_verificador(base_extendida, configuracion=configuracion)
+
+        rut = Rut(base_extendida, validador=validador)
+
+        assert str(rut) == f"{base_extendida}-{dv}"
+
+    def test_rut_con_digito_usa_configuracion_personalizada(self):
+        """El validador personalizado admite RUTs extendidos con dígito."""
+
+        configuracion = ConfiguracionRut(max_digitos=9)
+        validador = ValidadorRut(configuracion=configuracion)
+        base_extendida = "123456789"
+        dv = calcular_digito_verificador(base_extendida, configuracion=configuracion)
+
+        rut = Rut(f"{base_extendida}-{dv}", validador=validador)
+
+        assert str(rut) == f"{base_extendida}-{dv}"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- ensure `RutBase` reuses the caller's validator so custom configurations extend to the base normalization
- relax formato validation to honor the configured max digits and guard with a dedicated length check
- add regression tests and documentation notes covering extended-length RUT scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d43f71cd908328a71106067e8e66ad