### PR TITLE
Optimize batch RUT formatting and streaming paths

### DIFF
--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -13,6 +13,7 @@ from rutificador import (
     Rut,
     calcular_digito_verificador,
     DetalleError,
+    ProcesadorLotesRut,
     __version__,
 )
 from rutificador.formatter import FormateadorCSV
@@ -46,6 +47,15 @@ def test_rut_cache_management():
     Rut.limpiar_cache()
     stats = Rut.estadisticas_cache()
     assert stats["cache_size"] == 0
+
+
+def test_resultado_lote_expone_objetos_cacheados():
+    procesador = ProcesadorLotesRut()
+    resultado = procesador.validar_lista_ruts(["12345678-5", "12345678-9"])
+    assert len(resultado.objetos_rut_validos) == 1
+    rut_obj = resultado.objetos_rut_validos[0]
+    assert isinstance(rut_obj, Rut)
+    assert resultado.ruts_validos[0] == str(rut_obj)
 
 
 def test_global_validar_y_formatear():


### PR DESCRIPTION
## Summary
- cache Rut instances inside `ResultadoLote` so batch formatting reuses validated objects instead of re-parsing strings
- streamline streaming helpers to validate with a shared `ValidadorRut` and reuse freshly built Rut instances for formatting output
- extend unit coverage to assert the cached Rut objects are exposed for downstream consumers

## Testing
- `pytest`

## Benchmarks
- `python benchmarks/formateo_batch.py` *(synthetic script used inline)*
  - validar_lista_ruts: **0.0380s → 0.0413s** (≈ +8.7% from extra bookkeeping)
  - formatear_lista_ruts: **0.0884s → 0.0517s** (≈ −41.5% due to Rut reuse)


------
https://chatgpt.com/codex/tasks/task_e_68d442cc53ac8328bc7a3a4e0d199160